### PR TITLE
Remove restrictedTraverse

### DIFF
--- a/flake8_plone_api.py
+++ b/flake8_plone_api.py
@@ -93,7 +93,7 @@ DATA = {
     'content.get': {
         'since': '1.0',
         'replace': [
-            'restrictedTraverse(',
+            None,
         ],
     },
     'content.move': {


### PR DESCRIPTION
One can traverse to a lot of other things rather than only views.

This means that lots of false positives are reported.
